### PR TITLE
Clean up `getContext()` call.

### DIFF
--- a/src/lime/_internal/graphics/ImageCanvasUtil.hx
+++ b/src/lime/_internal/graphics/ImageCanvasUtil.hx
@@ -187,15 +187,13 @@ class ImageCanvasUtil
 			buffer.__srcCanvas.width = width;
 			buffer.__srcCanvas.height = height;
 
+			var contextAttributes = { };
 			if (!image.transparent)
 			{
-				if (!image.transparent) buffer.__srcCanvas.setAttribute("moz-opaque", "true");
-				buffer.__srcContext = untyped #if haxe4 js.Syntax.code #else __js__ #end ('buffer.__srcCanvas.getContext ("2d", { alpha: false })');
+				buffer.__srcCanvas.setAttribute("moz-opaque", "true");
+				contextAttributes.alpha = false;
 			}
-			else
-			{
-				buffer.__srcContext = buffer.__srcCanvas.getContext("2d");
-			}
+			buffer.__srcContext = buffer.__srcCanvas.getContext("2d", contextAttributes);
 		}
 		#end
 	}


### PR DESCRIPTION
My guess is we were using `untyped __js__` to get around incomplete externs, but all externs since Haxe 3.4 support a `Dynamic` second argument.

Also, the old code checked `!image.transparent` twice.