### PR TITLE
Pass `-rpi` flag to svg.n.

### DIFF
--- a/src/lime/tools/ImageHelper.hx
+++ b/src/lime/tools/ImageHelper.hx
@@ -28,6 +28,7 @@ class ImageHelper
 			System.runCommand("", "neko", [
 				Path.combine(Haxelib.getPath(new Haxelib(#if lime "lime" #else "hxp" #end)), "svg.n"),
 				"process",
+				#if rpi "-rpi", #end
 				path,
 				Std.string(width),
 				Std.string(height),

--- a/tools/SVGExport.hx
+++ b/tools/SVGExport.hx
@@ -140,7 +140,7 @@ class SVGExport
 			{
 				Log.verbose = true;
 			}
-			else
+			else if (arg != "-rpi")
 			{
 				words.push(arg);
 			}


### PR DESCRIPTION
`SVGExport` line 143 could be made more general by testing if `~/^\-[a-zA-Z]+$/` matches, but until more flags are added I don't think we need it.

We could also check `startsWith("-")`, but that could potentially exclude a valid filename.